### PR TITLE
simplify UK postcodes

### DIFF
--- a/pyap_beauhurst/source_GB/data.py
+++ b/pyap_beauhurst/source_GB/data.py
@@ -351,31 +351,6 @@ city = r"""
 
 postal_code = r"""
 (?P<postal_code>
-    # Girobank postcode
-    (?:[gG][iI][rR] {0,}0[aA]{2})|
-    (?:  # British Overseas Territories in usual format
-        (?:
-            [aA][sS][cC][nN]|
-            [sS][tT][hH][lL]|
-            [tT][dD][cC][uU]|
-            [bB][bB][nN][dD]|
-            [bB][iI][qQ][qQ]|
-            [fF][iI][qQ][qQ]|
-            [pP][cC][rR][nN]|
-            [sS][iI][qQ][qQ]|
-            [iT][kK][cC][aA]
-        )
-        \s{0,}1[zZ]{2}
-    )|
-    (?:  # British Overseas Territories in zip-code format
-        (KY[0-9]|MSR|VG|AI)[ -]{0,}[0-9]{4}
-    )|
-    # (?:  # Bermuda including this causes too many false positives, so excluded for now
-    #     [a-zA-Z]{2}\s{0,}[0-9]{2}
-    # )|
-    (?:  # British Forces Post Office
-        [Bb][Ff][Pp][Oo]\s{0,}[0-9]{1,4}
-    )|
     (?:  # Mainland British postcodes
         (?:
             (?:[Ww][Cc][0-9][abehmnprvwxyABEHMNPRVWXY])|


### PR DESCRIPTION
For our use case, we don't need to match to military bases or overseas territories...

https://github.com/Beauhurst/who-let-the-dags-out/pull/125 as mentioned here "mainland Britain" is a loose defintion - the GB regex still matches these:

ZE1 0AF Lerwick
HS1 2DD Stornoway
PH42 4RL Isle of Eigg
IM1 4EW Isle of Man
BT1 1DJ Belfast
BT47 2AW Derry 
