### PR TITLE
Postcode boundaries

### DIFF
--- a/pyap_beauhurst/source_GB/data.py
+++ b/pyap_beauhurst/source_GB/data.py
@@ -353,14 +353,14 @@ postal_code = r"""
 (?P<postal_code>
     (?:  # Mainland British postcodes
         (?:
-            (?:[Ww][Cc][0-9][abehmnprvwxyABEHMNPRVWXY])|
-            (?:[Ee][Cc][1-4][abehmnprvwxyABEHMNPRVWXY])|
-            (?:[Nn][Ww]1[Ww])|
-            (?:[Ss][Ee]1[Pp])|
-            (?:[Ss][Ww]1[abehmnprvwxyABEHMNPRVWXY])|
-            (?:[EeNnWw]1[a-hjkpstuwA-HJKPSTUW])|
-            (?:[BbEeGgLlMmNnSsWw][0-9][0-9]?)|
-            (?:[a-pr-uwyzA-PR-UWYZ][a-hk-yxA-HK-XY][0-9][0-9]?)
+            (?:\b[Ww][Cc][0-9][abehmnprvwxyABEHMNPRVWXY])|
+            (?:\b[Ee][Cc][1-4][abehmnprvwxyABEHMNPRVWXY])|
+            (?:\b[Nn][Ww]1[Ww])|
+            (?:\b[Ss][Ee]1[Pp])|
+            (?:\b[Ss][Ww]1[abehmnprvwxyABEHMNPRVWXY])|
+            (?:\b[EeNnWw]1[a-hjkpstuwA-HJKPSTUW])|
+            (?:\b[BbEeGgLlMmNnSsWw][0-9][0-9]?)|
+            (?:\b[a-pr-uwyzA-PR-UWYZ][a-hk-yxA-HK-XY][0-9][0-9]?)
         )
         \s{0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyap-beauhurst"
-version = "0.4.0"
+version = "0.4.1"
 description = "Pyap is an MIT Licensed text processing library, written in Python, for detecting and parsing addresses. Currently it supports USA, Canadian and British addresses. This is a fork maintained by Beauhurst."
 authors = ["Vladimir Goncharov <vladimarius@gmail.com>", "Beauhurst <dev@beauhurst.com>"]
 documentation = "https://github.com/Beauhurst/pyap"

--- a/tests/test_parser_gb.py
+++ b/tests/test_parser_gb.py
@@ -435,7 +435,9 @@ def test_postal_code(input_data: str, is_match_expected: bool) -> None:
         ("3 Dyer Street, Cirencester GL7 2PP", "GL7 2PP"),
     ],
 )
-def test_postcodes_with_valid_postcode_as_substring(input_data: str, expected_postcode: str) -> None:
+def test_postcodes_with_valid_postcode_as_substring(
+    input_data: str, expected_postcode: str
+) -> None:
     """
     Some Postcodes can be incorrectly matched to substring postcodes (like LS9 matching S9)
     """

--- a/tests/test_parser_gb.py
+++ b/tests/test_parser_gb.py
@@ -8,7 +8,7 @@ from io import TextIOWrapper
 import pytest
 import requests
 
-import pyap_beauhurst
+import pyap_beauhurst as pyap
 import pyap_beauhurst.source_GB.data as data_gb
 from pyap_beauhurst.address import Address
 from test_utils import execute_matching_test
@@ -427,6 +427,21 @@ def test_postal_code(input_data: str, is_match_expected: bool) -> None:
     execute_matching_test(input_data, is_match_expected, data_gb.postal_code)
 
 
+@pytest.mark.parametrize(
+    ("input_data", "expected_postcode"),
+    [
+        ("24 Moorfield Road, IIkley, West Yorkshire LS29 8BL, UK", "LS29 8BL"),
+        ("71 Wilson Avenue Rochester Kent ME1 2SJ", "ME1 2SJ"),
+        ("3 Dyer Street, Cirencester GL7 2PP", "GL7 2PP"),
+    ],
+)
+def test_specific_postcodes(input_data: str, expected_postcode: str) -> None:
+    """
+    Some Postcodes can be incorrectly matched to substring postcodes (like LS9 matching S9)
+    """
+    assert pyap.parse(input_data, country="GB")[0].postal_code == expected_postcode
+
+
 def test_postal_code_extensive() -> None:
     """Test post code regex against a list of all post codes."""
     zip_location = ".." / pathlib.Path(__file__).parent / "code_point_uk_post_codes.zip"
@@ -586,8 +601,8 @@ def test_full_address_parts() -> None:
                     + filler_text_after
                 )
 
-                parsed = pyap_beauhurst.parse(address_text, country="GB")
-                print(pyap_beauhurst.AddressParser._normalize_string(address_text))
+                parsed = pyap.parse(address_text, country="GB")
+                print(pyap.AddressParser._normalize_string(address_text))
                 # Ensure that only one address is found
                 assert len(parsed) == 1
                 for k, v in address_parts.items():
@@ -597,9 +612,7 @@ def test_full_address_parts() -> None:
                         if initial_parsed.dict().get("full_address"):
                             assert (
                                 initial_parsed.full_address
-                                == pyap_beauhurst.parser.AddressParser._normalize_string(
-                                    v
-                                )
+                                == pyap.parser.AddressParser._normalize_string(v)
                             )
                     else:
                         # assert that every item in the above address

--- a/tests/test_parser_gb.py
+++ b/tests/test_parser_gb.py
@@ -435,7 +435,7 @@ def test_postal_code(input_data: str, is_match_expected: bool) -> None:
         ("3 Dyer Street, Cirencester GL7 2PP", "GL7 2PP"),
     ],
 )
-def test_specific_postcodes(input_data: str, expected_postcode: str) -> None:
+def test_postcodes_with_valid_postcode_as_substring(input_data: str, expected_postcode: str) -> None:
     """
     Some Postcodes can be incorrectly matched to substring postcodes (like LS9 matching S9)
     """


### PR DESCRIPTION
This PR fixes a bug where some UK postcodes were being incorrectly matched. Example below:

71 Wilson Avenue Rochester Kent ME1 2SJ postcode was extracted as E1 2SJ, which is a valid postcode, and a substring of the actual postcode. 

This is fixed by adding word boundaries to the beginning of the postcode regex patterns.